### PR TITLE
Replace singleton qmi with per-ifname one

### DIFF
--- a/lib/vintage_net_qmi.ex
+++ b/lib/vintage_net_qmi.ex
@@ -11,8 +11,8 @@ defmodule VintageNetQMI do
   @doc """
   Name of the the QMI server that VintageNetQMI uses
   """
-  @spec qmi_name() :: QMI.nme()
-  def qmi_name(), do: QMI
+  @spec qmi_name(VintageNet.ifname()) :: atom()
+  def qmi_name(ifname), do: Module.concat(VintageNetQMI.QMI, ifname)
 
   @impl VintageNet.Technology
   def normalize(config) do
@@ -34,8 +34,8 @@ defmodule VintageNetQMI do
     ]
 
     child_specs = [
-      {QMI, [ifname: "wwan0", name: qmi_name()]},
-      {VintageNetQMI.Connection, [service_provider: qmi.service_provider]},
+      {QMI, [ifname: ifname, name: qmi_name(ifname)]},
+      {VintageNetQMI.Connection, [ifname: ifname, service_provider: qmi.service_provider]},
       {VintageNetQMI.CellMonitor, [ifname: ifname]},
       {VintageNetQMI.SignalMonitor, [ifname: ifname]}
     ]

--- a/lib/vintage_net_qmi/cell_monitor.ex
+++ b/lib/vintage_net_qmi/cell_monitor.ex
@@ -9,7 +9,12 @@ defmodule VintageNetQMI.CellMonitor do
   alias QMI.NetworkAccess
 
   defp init_state(ifname, poll_interval) do
-    %{ifname: ifname, poll_interval: poll_interval, poll_reference: nil}
+    %{
+      ifname: ifname,
+      qmi: VintageNetQMI.qmi_name(ifname),
+      poll_interval: poll_interval,
+      poll_reference: nil
+    }
   end
 
   def start_link(args) do
@@ -34,7 +39,7 @@ defmodule VintageNetQMI.CellMonitor do
     {:ok, poll_ref} = :timer.send_interval(state.poll_interval, :poll)
 
     state =
-      get_home_network()
+      NetworkAccess.get_home_network(state.qmi)
       |> maybe_post_home_network(state)
       |> put_poll_ref(poll_ref)
 
@@ -43,7 +48,7 @@ defmodule VintageNetQMI.CellMonitor do
 
   def handle_info(:poll, state) do
     state =
-      get_home_network()
+      NetworkAccess.get_home_network(state.qmi)
       |> maybe_post_home_network(state)
 
     {:noreply, state}

--- a/lib/vintage_net_qmi/connection.ex
+++ b/lib/vintage_net_qmi/connection.ex
@@ -29,9 +29,11 @@ defmodule VintageNetQMI.Connection do
 
   @impl GenServer
   def init(args) do
+    ifname = Keyword.fetch!(args, :ifname)
     service_provider = Keyword.fetch!(args, :service_provider)
 
     state = %{
+      qmi: VintageNetQMI.qmi_name(ifname),
       service_provider: service_provider
     }
 
@@ -42,7 +44,7 @@ defmodule VintageNetQMI.Connection do
 
   @impl GenServer
   def handle_info(:connect, state) do
-    case WirelessData.start_network_interface(VintageNetQMI.qmi_name(),
+    case WirelessData.start_network_interface(state.qmi,
            apn: state.service_provider
          ) do
       {:ok, _} ->

--- a/lib/vintage_net_qmi/signal_monitor.ex
+++ b/lib/vintage_net_qmi/signal_monitor.ex
@@ -23,6 +23,7 @@ defmodule VintageNetQMI.SignalMonitor do
 
     state = %{
       ifname: ifname,
+      qmi: VintageNetQMI.qmi_name(ifname),
       interval: interval
     }
 
@@ -39,8 +40,7 @@ defmodule VintageNetQMI.SignalMonitor do
   end
 
   defp get_signal_stats(state) do
-    {:ok, %{rssi_reports: [rssi_data]}} =
-      NetworkAccess.get_signal_strength(VintageNetQMI.qmi_name())
+    {:ok, %{rssi_reports: [rssi_data]}} = NetworkAccess.get_signal_strength(state.qmi)
 
     rssi_data
     |> to_rssi()

--- a/test/vintage_net_qmi_test.exs
+++ b/test/vintage_net_qmi_test.exs
@@ -16,8 +16,8 @@ defmodule VintageNetQMITest do
       source_config: input,
       required_ifnames: ["wwan0"],
       child_specs: [
-        {QMI, [ifname: "wwan0", name: QMI]},
-        {VintageNetQMI.Connection, [service_provider: "super"]},
+        {QMI, [ifname: "wwan0", name: :"Elixir.VintageNetQMI.QMI.wwan0"]},
+        {VintageNetQMI.Connection, [{:ifname, "wwan0"}, {:service_provider, "super"}]},
         {VintageNetQMI.CellMonitor, [ifname: "wwan0"]},
         {VintageNetQMI.SignalMonitor, [ifname: "wwan0"]},
         Utils.udhcpc_child_spec("wwan0", "unit_test"),


### PR DESCRIPTION
This allows more than one LTE module to be connected and removes one
place where `"wwan0"` was hardcoded.
