### PR TITLE
Align config to vintage_net_mobile; change how DHCP gets started

### DIFF
--- a/lib/vintage_net_qmi.ex
+++ b/lib/vintage_net_qmi.ex
@@ -1,31 +1,119 @@
 defmodule VintageNetQMI do
   @moduledoc """
-  %{type: VintageNetQMI, vintage_net_qmi: %{service_provider: ""}, ipv4: %{method: :dhcp}}
+  Use a QMI-enabled cellular modem with VintageNet
+
+  This module is not intended to be called directly but via calls to `VintageNet`. Here's a
+  typical example:
+
+  ```elixir
+  VintageNet.configure(
+    "wwan0",
+    %{
+      type: VintageNetQMI,
+      vintage_net_qmi: %{
+        service_providers: [%{apn: "super"}]
+      }
+    }
+  )
+  ```
+
+  The following keys are supported
+
+  * `:service_providers` - This is a list of service provider information
+
+  The `:service_providers` key should be set to information provided by each of
+  your service providers. Currently only the first service provider is used.
+
+  Information for each service provider is a map with some or all of the following
+  fields:
+
+  * `:apn` (required) - e.g., `"access_point_name"`
+
+  Your service provider should provide you with the information that you need to
+  connect. Often it is just an APN. The Gnome project provides a database of
+  [service provider
+  information](https://wiki.gnome.org/Projects/NetworkManager/MobileBroadband/ServiceProviders)
+  that may also be useful.
+
+  Here's an example with a service provider list:
+
+  ```elixir
+    %{
+      type: VintageNetQMI,
+      vintage_net_qmi: %{
+        service_providers: [
+          %{apn: "wireless.twilio.com"}
+        ],
+      }
+    }
+  ```
   """
 
   @behaviour VintageNet.Technology
 
   alias VintageNet.Interface.RawConfig
-  alias VintageNet.IP.{DhcpdConfig, IPv4Config}
 
   @doc """
   Name of the the QMI server that VintageNetQMI uses
   """
   @spec qmi_name(VintageNet.ifname()) :: atom()
-  def qmi_name(ifname), do: Module.concat(VintageNetQMI.QMI, ifname)
+  def qmi_name(ifname), do: Module.concat(__MODULE__.QMI, ifname)
 
   @impl VintageNet.Technology
-  def normalize(config) do
-    config
-    |> IPv4Config.normalize()
-    |> DhcpdConfig.normalize()
+  def normalize(%{type: __MODULE__, vintage_net_qmi: _qmi} = config) do
+    require_a_service_provider(config)
+  end
+
+  def normalize(_config) do
+    raise ArgumentError,
+          "specify an vintage_net_qmi options (service_providers: [%{apn: \"super\"}])"
+  end
+
+  defp require_a_service_provider(
+         %{type: __MODULE__, vintage_net_qmi: qmi} = config,
+         required_fields \\ [:apn]
+       ) do
+    case Map.get(qmi, :service_providers, []) do
+      [] ->
+        service_provider =
+          for field <- required_fields, into: %{} do
+            {field, to_string(field)}
+          end
+
+        new_config = %{
+          config
+          | vintage_net_qmi: Map.put(qmi, :service_providers, [service_provider])
+        }
+
+        raise ArgumentError,
+              """
+              At least one service provider is required for #{__MODULE__}.
+
+              For example:
+
+              #{inspect(new_config)}
+              """
+
+      [service_provider | _rest] ->
+        missing =
+          Enum.find(required_fields, fn field -> not Map.has_key?(service_provider, field) end)
+
+        if missing do
+          raise ArgumentError,
+                """
+                The service provider '#{inspect(service_provider)}' is missing the `inspect(missing)' field.
+                """
+        end
+
+        config
+    end
   end
 
   @impl VintageNet.Technology
   def to_raw_config(
         ifname,
-        %{type: __MODULE__, vintage_net_qmi: qmi} = config,
-        opts
+        %{type: __MODULE__} = config,
+        _opts
       ) do
     normalized_config = normalize(config)
 
@@ -35,10 +123,14 @@ defmodule VintageNetQMI do
 
     child_specs = [
       {QMI, [ifname: ifname, name: qmi_name(ifname)]},
-      {VintageNetQMI.Connection, [ifname: ifname, service_provider: qmi.service_provider]},
+      {VintageNetQMI.Connection,
+       [ifname: ifname, service_providers: normalized_config.vintage_net_qmi.service_providers]},
       {VintageNetQMI.CellMonitor, [ifname: ifname]},
       {VintageNetQMI.SignalMonitor, [ifname: ifname]}
     ]
+
+    # QMI uses DHCP to report IP addresses, gateway, DNS, etc.
+    ipv4_config = %{ipv4: %{method: :dhcp}, hostname: Map.get(config, :hostname)}
 
     config =
       %RawConfig{
@@ -49,10 +141,19 @@ defmodule VintageNetQMI do
         up_cmds: up_cmds,
         child_specs: child_specs
       }
-      |> IPv4Config.add_config(normalized_config, opts)
-      |> DhcpdConfig.add_config(normalized_config, opts)
+      |> VintageNet.IP.IPv4Config.add_config(ipv4_config, [])
+      |> remove_connectivity_detector()
 
     config
+  end
+
+  defp remove_connectivity_detector(raw_config) do
+    new_child_specs =
+      Enum.filter(raw_config.child_specs, fn spec ->
+        !match?({VintageNet.Interface.InternetConnectivityChecker, _ifname}, spec)
+      end)
+
+    %{raw_config | child_specs: new_child_specs}
   end
 
   @impl VintageNet.Technology

--- a/test/vintage_net_qmi_test.exs
+++ b/test/vintage_net_qmi_test.exs
@@ -2,11 +2,10 @@ defmodule VintageNetQMITest do
   use ExUnit.Case
   alias VintageNet.Interface.RawConfig
 
-  test "create a wired ethernet configuration" do
+  test "create a simple qmi configuration" do
     input = %{
       type: VintageNetQMI,
-      vintage_net_qmi: %{service_provider: "super", device: "/dev/cdc-wdm0"},
-      ipv4: %{method: :dhcp},
+      vintage_net_qmi: %{service_providers: [%{apn: "super"}]},
       hostname: "unit_test"
     }
 
@@ -17,11 +16,10 @@ defmodule VintageNetQMITest do
       required_ifnames: ["wwan0"],
       child_specs: [
         {QMI, [ifname: "wwan0", name: :"Elixir.VintageNetQMI.QMI.wwan0"]},
-        {VintageNetQMI.Connection, [{:ifname, "wwan0"}, {:service_provider, "super"}]},
+        {VintageNetQMI.Connection, [{:ifname, "wwan0"}, service_providers: [%{apn: "super"}]]},
         {VintageNetQMI.CellMonitor, [ifname: "wwan0"]},
         {VintageNetQMI.SignalMonitor, [ifname: "wwan0"]},
-        Utils.udhcpc_child_spec("wwan0", "unit_test"),
-        {VintageNet.Interface.InternetConnectivityChecker, "wwan0"}
+        Utils.udhcpc_child_spec("wwan0", "unit_test")
       ],
       down_cmds: [
         {:run_ignore_errors, "ip", ["addr", "flush", "dev", "wwan0", "label", "wwan0"]},


### PR DESCRIPTION
This makes the provider configuration look the same as
vintage_net_mobile and makes it so that the user doesn't need to also
configure DHCP. DHCP will be configured for them.
