### PR TITLE
Fix quick_configure/1

### DIFF
--- a/lib/vintage_net_qmi/cookbook.ex
+++ b/lib/vintage_net_qmi/cookbook.ex
@@ -14,7 +14,7 @@ defmodule VintageNetQMI.Cookbook do
      %{
        type: VintageNetQMI,
        vintage_net_qmi: %{
-         service_providers: [%{apn: "apn"}]
+         service_providers: [%{apn: apn}]
        }
      }}
   end

--- a/test/vintage_net_qmi/cookbook_test.exs
+++ b/test/vintage_net_qmi/cookbook_test.exs
@@ -4,7 +4,7 @@ defmodule VintageNetQMI.CookbookTest do
   alias VintageNetQMI.Cookbook
 
   test "simple/1" do
-    assert {:ok, %{type: VintageNetQMI, vintage_net_qmi: %{service_providers: [%{apn: "apn"}]}}} ==
+    assert {:ok, %{type: VintageNetQMI, vintage_net_qmi: %{service_providers: [%{apn: "super"}]}}} ==
              Cookbook.simple("super")
   end
 end


### PR DESCRIPTION
This was hardcoding `"apn"` instead of using the user-supplied
apn value.