### PR TITLE
Fix lease renewal ending in stuck lan connectivity

### DIFF
--- a/lib/vintage_net_qmi/connectivity.ex
+++ b/lib/vintage_net_qmi/connectivity.ex
@@ -71,7 +71,7 @@ defmodule VintageNetQMI.Connectivity do
 
   @impl GenServer
   def handle_info(
-        {VintageNet, ["interface", ifname, "connection"], :disconnected, :lan, _meta},
+        {VintageNet, ["interface", ifname, "connection"], _, :lan, _meta},
         %{ifname: ifname} = state
       ) do
     new_state =


### PR DESCRIPTION
When the lease would renew the connectivity goes from `:internet` to
`:lan` due to the UDHPC code in `VintageNet`. This change will account
for when `VintageNet` changes the connection to `:lan` and will force
the connection to either be `:disconnected` or `:internet` based off the
QMI connectivity requirements.