### PR TITLE
Require qmi 0.6.3 or later

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule VintageNetQMI.MixProject do
   defp deps do
     [
       {:vintage_net, "~> 0.10.0 or ~> 0.11.0"},
-      {:qmi, "~> 0.6.0"},
+      {:qmi, "~> 0.6.3"},
       {:credo, "~> 1.5", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.1.0", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.23", only: :docs, runtime: false},


### PR DESCRIPTION
This fixes:

```
** (UndefinedFunctionError) function QMI.DeviceManagement.get_serial_numbers/1 is undefined or private
```
