### PR TITLE
Watch connection status for power control watchdog

### DIFF
--- a/lib/vintage_net_qmi/connectivity.ex
+++ b/lib/vintage_net_qmi/connectivity.ex
@@ -3,6 +3,7 @@ defmodule VintageNetQMI.Connectivity do
 
   use GenServer
 
+  alias VintageNet.PowerManager.PMControl
   alias VintageNet.RouteManager
 
   @typedoc """
@@ -68,6 +69,8 @@ defmodule VintageNetQMI.Connectivity do
       }
       |> update_connection_status()
 
+    _ = :timer.send_interval(60, :check_connectivity)
+
     {:ok, state}
   end
 
@@ -113,6 +116,14 @@ defmodule VintageNetQMI.Connectivity do
       |> update_connection_status()
 
     {:noreply, new_state}
+  end
+
+  def handle_info(:check_connectivity, state) do
+    if state.cached_status == :internet do
+      PMControl.pet_watchdog(state.ifname)
+    end
+
+    {:noreply, state}
   end
 
   def handle_info(_message, state), do: {:noreply, state}

--- a/lib/vintage_net_qmi/signal_monitor.ex
+++ b/lib/vintage_net_qmi/signal_monitor.ex
@@ -4,12 +4,12 @@ defmodule VintageNetQMI.SignalMonitor do
   use GenServer
 
   alias QMI.NetworkAccess
-  alias VintageNet.PowerManager.PMControl
   alias VintageNet.PropertyTable
   alias VintageNetQMI.ASUCalculator
 
   @type opt() :: {:ifname, binary()} | {:interval, non_neg_integer()}
 
+  @spec start_link([opt()]) :: GenServer.on_start()
   def start_link(args) do
     GenServer.start_link(__MODULE__, args)
   end
@@ -44,17 +44,11 @@ defmodule VintageNetQMI.SignalMonitor do
 
     rssi_data
     |> to_rssi()
-    |> maybe_pet_power_control(state.ifname)
     |> post_signal_rssi(state.ifname)
   end
 
   defp to_rssi(%{rssi: rssi}) do
     ASUCalculator.from_lte_rssi(rssi)
-  end
-
-  defp maybe_pet_power_control(%{bars: bars} = report, ifname) when bars > 0 do
-    PMControl.pet_watchdog(ifname)
-    report
   end
 
   defp post_signal_rssi(%{asu: asu, dbm: dbm, bars: bars}, ifname) do


### PR DESCRIPTION
VintageNet's power management relies on regularly being told that
everything is ok. If it's not told for a long time (configurable, but
usually minutes), then it will restart the network interface.

The previous code monitored the signal strength. So long as there was a
signal, everything was good.

It turns out that there's a case where you can be connected to a cell
tower, but all network traffic is disallowed. Pressing buttons on
Twilio's UI can fix this. However, the device needs to reconnect.

This commit moves the watchdog petting logic to the connectivity check
logic that knows whether higher level network is available. This code
can recover from the issue just described.
