### PR TITLE
Fix crash when there are no addresses on the interface

### DIFF
--- a/lib/vintage_net_qmi/connectivity.ex
+++ b/lib/vintage_net_qmi/connectivity.ex
@@ -175,6 +175,8 @@ defmodule VintageNetQMI.Connectivity do
 
   defp update_connection_status(state), do: state
 
+  defp has_ipv4_address?(nil), do: false
+
   defp has_ipv4_address?(addresses) do
     Enum.any?(addresses, &ipv4?/1)
   end


### PR DESCRIPTION
This fixes:

```
14:31:10.277 [error] GenServer :"Elixir.VintageNetQMI.Connectivity.wwan0" terminating
** (Protocol.UndefinedError) protocol Enumerable not implemented for nil of type Atom.
    (elixir 1.12.3) lib/enum.ex:1: Enumerable.impl_for!/1
    (elixir 1.12.3) lib/enum.ex:141: Enumerable.reduce/3
    (elixir 1.12.3) lib/enum.ex:403: Enum.any?/2
    (vintage_net_qmi 0.2.9) lib/vintage_net_qmi/connectivity.ex:144: VintageNetQMI.Connectivity.handle_info/2
    (stdlib 3.16.1) gen_server.erl:695: :gen_server.try_dispatch/4
    (stdlib 3.16.1) gen_server.erl:771: :gen_server.handle_msg/6
    (stdlib 3.16.1) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
Last message: {VintageNet, ["interface", "wwan0", "addresses"], [], nil, %{}}
State: %{cached_status: :disconnected, cached_status_timestamp: 2471470441115, ifname: "wwan0", ip_address?: false, lan?: true, packet_data_connection: :disconnected, serving_system?: true}
```
