### PR TITLE
Silently ignore all of the sync indications

### DIFF
--- a/lib/vintage_net_qmi/indications.ex
+++ b/lib/vintage_net_qmi/indications.ex
@@ -49,6 +49,11 @@ defmodule VintageNetQMI.Indications do
     {:noreply, state}
   end
 
+  def handle_cast({:indication, %{name: :sync_indication}}, state) do
+    # Silently ignore sync indications
+    {:noreply, state}
+  end
+
   def handle_cast({:indication, indication}, state) do
     Logger.info("VintageNetQMI: ignoring indication: #{inspect(indication)}")
     {:noreply, state}


### PR DESCRIPTION
These seem to fill up the logs and don't appear to be important.
