### PR TITLE
Report the active APN in the property table

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ technology the following:
 | `channel`     | integer        | An integer that indicates the channel that's in use |
 | `manufacturer` | string        | The name of the manufacturer of the modem |
 | `model`       | string         | The name of the model of the modem        |
+| `apn`         | string         | The APN that VintageNetQMI configured the modem to use |
 
 The following properties are TBD:
 

--- a/lib/vintage_net_qmi/connection.ex
+++ b/lib/vintage_net_qmi/connection.ex
@@ -118,6 +118,7 @@ defmodule VintageNetQMI.Connection do
            ServiceProvider.select_apn_by_iccid(state.service_providers, state.iccid),
          {:ok, _} <- WirelessData.start_network_interface(state.qmi, apn: apn) do
       Logger.info("[VintageNetQMI]: network started. Waiting on DHCP")
+      PropertyTable.put(VintageNet, ["interface", state.ifname, "mobile", "apn"], apn)
       state
     else
       nil ->


### PR DESCRIPTION
Now that VintageNetQMI supports selecting from a list of APNs it would
be nice to be able to retrieve this information programmatically.

Also, this will allow easier use of debugging and/or information
gathering by a human as we wont have to compare the ICCID with the
configured prefixes to figure out which APN is in use.
