### PR TITLE
Fix infinite retries to connect after a connection has be established

### DIFF
--- a/lib/vintage_net_qmi/connection.ex
+++ b/lib/vintage_net_qmi/connection.ex
@@ -116,9 +116,9 @@ defmodule VintageNetQMI.Connection do
   defp try_to_connect(state) do
     with apn when apn != nil <-
            ServiceProvider.select_apn_by_iccid(state.service_providers, state.iccid),
+         :ok <- PropertyTable.put(VintageNet, ["interface", state.ifname, "mobile", "apn"], apn),
          {:ok, _} <- WirelessData.start_network_interface(state.qmi, apn: apn) do
       Logger.info("[VintageNetQMI]: network started. Waiting on DHCP")
-      PropertyTable.put(VintageNet, ["interface", state.ifname, "mobile", "apn"], apn)
       state
     else
       nil ->

--- a/lib/vintage_net_qmi/connection.ex
+++ b/lib/vintage_net_qmi/connection.ex
@@ -128,6 +128,11 @@ defmodule VintageNetQMI.Connection do
 
         state
 
+      {:error, :no_effect} ->
+        # no effect means that a network connection as already be established
+        # so we don't need to try to connect again.
+        state
+
       {:error, reason} ->
         Logger.warn(
           "[VintageNetQMI]: could not connect for #{inspect(reason)}. Retrying in #{inspect(state.connect_retry_interval)} ms."


### PR DESCRIPTION
Sometimes the QMI command to start a network connection takes longer to
process than the timeout point for QMI. When this happens a good network
connection is established but VintageNetQMI does not think there is a
good network connection.

This fix handles the `:no_effect` error reason so that VintageNetQMI does
not continue to retry establishing a connection as that return value, per
the specification, means that there already is a good connection
established.
