### PR TITLE
Restrict calculated ASU values to 0-31, 99

### DIFF
--- a/lib/vintage_net_qmi/asu_calculator.ex
+++ b/lib/vintage_net_qmi/asu_calculator.ex
@@ -67,6 +67,7 @@ defmodule VintageNetQMI.ASUCalculator do
   end
 
   defp dbm_to_gsm_asu(dbm) when dbm <= -113, do: 99
+  defp dbm_to_gsm_asu(dbm) when dbm >= -50, do: 31
 
   defp dbm_to_gsm_asu(dbm) do
     div(dbm + 113, 2)

--- a/test/vintage_net_qmi/asu_calculator_test.exs
+++ b/test/vintage_net_qmi/asu_calculator_test.exs
@@ -25,11 +25,14 @@ defmodule VintageNetQMI.ASUCalculatorTest do
   end
 
   test "computes lte asu" do
-    # Really, the only important thing here is that -113 goes to 99
-    # since 99 is a special number.
+    # The calculator only supports values 0-31 and 99, so
+    # check that it doesn't return anything out of range.
+    assert ASUCalculator.from_lte_rssi(-200).asu == 99
     assert ASUCalculator.from_lte_rssi(-113).asu == 99
     assert ASUCalculator.from_lte_rssi(-112).asu == 0
-    assert ASUCalculator.from_lte_rssi(0).asu == 56
+    assert ASUCalculator.from_lte_rssi(-52).asu == 30
+    assert ASUCalculator.from_lte_rssi(-49).asu == 31
+    assert ASUCalculator.from_lte_rssi(0).asu == 31
   end
 
   test "computes lte bars" do


### PR DESCRIPTION
The values 0-31, 99 are well known and expected. After that, things
depend. Sometimes an extended range from 100-199 is used. The existing
calculation can return values between 31 and 99 (most often 32), and
that was unexpected.
