### PR TITLE
Bug: Fix FunctionClauseError when ICCID is not binary

### DIFF
--- a/lib/vintage_net_qmi/service_provider.ex
+++ b/lib/vintage_net_qmi/service_provider.ex
@@ -26,7 +26,7 @@ defmodule VintageNetQMI.ServiceProvider do
   def select_provider_by_iccid(providers, iccid) do
     Enum.reduce_while(providers, nil, fn
       %{only_iccid_prefixes: prefixes} = provider, default ->
-        if String.starts_with?(iccid, prefixes) do
+        if is_binary(iccid) && String.starts_with?(iccid, prefixes) do
           {:halt, provider}
         else
           {:cont, default}

--- a/test/vintage_net_qmi/service_provider_test.exs
+++ b/test/vintage_net_qmi/service_provider_test.exs
@@ -57,5 +57,16 @@ defmodule VintageNetQMI.ServiceProviderTest do
 
       assert List.first(providers) == ServiceProvider.select_provider_by_iccid(providers, iccid)
     end
+
+    test "when iccid is nil select default without ICCID" do
+      providers = [
+        %{apn: "this one"},
+        %{apn: "not me", only_iccid_prefixes: ["89171717"]}
+      ]
+
+      iccid = nil
+
+      assert List.first(providers) == ServiceProvider.select_provider_by_iccid(providers, iccid)
+    end
   end
 end


### PR DESCRIPTION
In cases where ICCID is not binary do not attempt to run it through `String.starts_with` and prevent it blowing from up with `FunctionClauseError`. When the ICCID is not binary the default will be selected. 