### PR TITLE
Fix crash when trying to connect w/o an ICCID

### DIFF
--- a/lib/vintage_net_qmi/modem_info.ex
+++ b/lib/vintage_net_qmi/modem_info.ex
@@ -8,6 +8,8 @@ defmodule VintageNetQMI.ModemInfo do
   @iccid_file_id 0x2FE2
   @main_file_path 0x3F00
 
+  @info_retry_delay 5_000
+
   use GenServer, restart: :transient
 
   require Logger
@@ -125,7 +127,7 @@ defmodule VintageNetQMI.ModemInfo do
   end
 
   defp retry(name) do
-    Process.send_after(self(), name, 1_000)
+    Process.send_after(self(), name, @info_retry_delay)
   end
 
   @impl GenServer

--- a/lib/vintage_net_qmi/modem_info.ex
+++ b/lib/vintage_net_qmi/modem_info.ex
@@ -61,7 +61,7 @@ defmodule VintageNetQMI.ModemInfo do
         return_value(%{state | iccid: true})
 
       {:error, reason} ->
-        Logger.warning("[VintageNetQMI] unable to get CCID for #{inspect(reason)}")
+        Logger.warning("[VintageNetQMI] unable to get ICCID for #{inspect(reason)}")
         retry_and_return(:get_iccid, state)
     end
   end

--- a/lib/vintage_net_qmi/service_provider.ex
+++ b/lib/vintage_net_qmi/service_provider.ex
@@ -22,18 +22,18 @@ defmodule VintageNetQMI.ServiceProvider do
   @doc """
   Select the provider by the iccid
   """
-  @spec select_provider_by_iccid([t()], binary()) :: t() | nil
+  @spec select_provider_by_iccid([t()], binary()) :: {:ok, t()} | {:error, :no_provider}
   def select_provider_by_iccid(providers, iccid) do
-    Enum.reduce_while(providers, nil, fn
-      %{only_iccid_prefixes: prefixes} = provider, default ->
+    Enum.reduce_while(providers, {:error, :no_provider}, fn
+      %{only_iccid_prefixes: prefixes} = provider, best ->
         if is_binary(iccid) && String.starts_with?(iccid, prefixes) do
-          {:halt, provider}
+          {:halt, {:ok, provider}}
         else
-          {:cont, default}
+          {:cont, best}
         end
 
       provider, _default ->
-        {:cont, provider}
+        {:cont, {:ok, provider}}
     end)
   end
 end

--- a/test/vintage_net_qmi/service_provider_test.exs
+++ b/test/vintage_net_qmi/service_provider_test.exs
@@ -8,7 +8,7 @@ defmodule VintageNetQMI.ServiceProviderTest do
       provider = %{apn: "fake"}
       iccid = "891004234814455936F"
 
-      assert provider == ServiceProvider.select_provider_by_iccid([provider], iccid)
+      assert {:ok, provider} == ServiceProvider.select_provider_by_iccid([provider], iccid)
     end
 
     test "when prefix option matches the ICCID prefixes" do
@@ -22,15 +22,18 @@ defmodule VintageNetQMI.ServiceProviderTest do
 
       [first_provider, second_provider | _] = providers
 
-      assert first_provider == ServiceProvider.select_provider_by_iccid(providers, first_iccid)
-      assert second_provider == ServiceProvider.select_provider_by_iccid(providers, second_iccid)
+      assert {:ok, first_provider} ==
+               ServiceProvider.select_provider_by_iccid(providers, first_iccid)
+
+      assert {:ok, second_provider} ==
+               ServiceProvider.select_provider_by_iccid(providers, second_iccid)
     end
 
     test "when prefix option does not match ICCID prefix" do
       provider = %{apn: "not me", only_iccid_prefixes: ["89171717"]}
       iccid = "891004234814455936F"
 
-      assert nil ==
+      assert {:error, :no_provider} ==
                ServiceProvider.select_provider_by_iccid([provider], iccid)
     end
 
@@ -44,7 +47,7 @@ defmodule VintageNetQMI.ServiceProviderTest do
 
       [_, this_one | _] = providers
 
-      assert this_one == ServiceProvider.select_provider_by_iccid(providers, iccid)
+      assert {:ok, this_one} == ServiceProvider.select_provider_by_iccid(providers, iccid)
     end
 
     test "default to service provider with out ICCID selection when non match" do
@@ -55,7 +58,8 @@ defmodule VintageNetQMI.ServiceProviderTest do
 
       iccid = "8947571711111111FF"
 
-      assert List.first(providers) == ServiceProvider.select_provider_by_iccid(providers, iccid)
+      assert {:ok, List.first(providers)} ==
+               ServiceProvider.select_provider_by_iccid(providers, iccid)
     end
 
     test "when iccid is nil select default without ICCID" do
@@ -66,7 +70,8 @@ defmodule VintageNetQMI.ServiceProviderTest do
 
       iccid = nil
 
-      assert List.first(providers) == ServiceProvider.select_provider_by_iccid(providers, iccid)
+      assert {:ok, List.first(providers)} ==
+               ServiceProvider.select_provider_by_iccid(providers, iccid)
     end
   end
 end


### PR DESCRIPTION
If there are problems reading the ICCID off the SIM card, the APN
selection code repeatedly raises an exception.

This isn't good. It would be much better to log an error and raise an
alarm in a more general way.

This updates the code to validate the ICCID before trying to select an
APN. The code in the `with` was really hard to read, so this modifies
function calls to make it easier. The modifications are not intended to
change any semantics.
