### PR TITLE
Change failed configuration retries from 5s -> 30s

### DIFF
--- a/lib/vintage_net_qmi/connection.ex
+++ b/lib/vintage_net_qmi/connection.ex
@@ -11,7 +11,7 @@ defmodule VintageNetQMI.Connection do
 
   require Logger
 
-  @configuration_retry 5_000
+  @configuration_retry 30_000
 
   @typedoc """
   Options for to establish the connection


### PR DESCRIPTION
Failed configurations sometimes resolve themselves, but retrying every
5s causes a lot of errors to be logged when they don't.
