### PR TITLE
Update kernel config to enable option needed for others

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,8 +206,14 @@ official Nerves systems.
 Enable QMI and drivers for your modem:
 
 ```text
+CONFIG_USB_USBNET=m
 CONFIG_USB_NET_CDC_NCM=m
-CONFIG_USB_NET_HUAWEI_CDC_NCM=m
 CONFIG_USB_NET_QMI_WWAN=m
 CONFIG_USB_SERIAL_OPTION=m
+```
+
+If you're using a Huawei modem, you might also want:
+
+```text
+CONFIG_USB_NET_HUAWEI_CDC_NCM=m
 ```


### PR DESCRIPTION
Without `CONFIG_USB_USBNET=m`, the other options aren't available so
people copy/pasting the kernel config updates would end up not selecting
any drivers. This also moves the Huawei option since it shouldn't be
needed for most QMI users.
