### PR TITLE
Handle unexpected values in cell_monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,14 +140,14 @@ technology the following:
 | `signal_asu`  | `0-31,99`      | Reported Arbitrary Strength Unit (ASU) |
 | `signal_4bars` | `0-4`         | The signal level in "bars"    |
 | `signal_dbm`  | `-144 - -44`   | The signal level in dBm. Interpretation depends on the connection technology. |
-| `mcc`         | `0-999`        | Mobile Country Code for the network |
-| `mnc`         | `0-999`        | Mobile Network Code for the network |
+| `mcc`         | `0-999` | `nil`| Mobile Country Code for the network |
+| `mnc`         | `0-999` | `nil`| Mobile Network Code for the network |
 | `iccid`       | string         | The Integrated Circuit Card Identifier (ICCID) |
 | `esn`         | string         | The Electronic Serial Number (ESN) |
 | `imei`        | string         | International Mobile Equipment Identity (IMEI) |
 | `meid`        | string         | The Mobile Equipment Identifier (MEID) |
 | `imeisv_svn`  | string         | IMEI software version number |
-| `provider`    | string         | The name of the service provider |
+| `provider`    | string | `nil` | The name of the service provider |
 | `lac`         | `0-65533`      | The Location Area Code (lac) for the current cell |
 | `cid`         | `0-268435455`  | The Cell ID (cid) for the current cell |
 | `network_datetime` | `NaiveDateTime.t()` | The reported datetime from the network |
@@ -161,6 +161,7 @@ technology the following:
 | `manufacturer` | string        | The name of the manufacturer of the modem |
 | `model`       | string         | The name of the model of the modem        |
 | `apn`         | string         | The APN that VintageNetQMI configured the modem to use |
+| `sim_rej_info`| atom           | The reason (if any) a SIM was rejected |
 
 The following properties are TBD:
 

--- a/lib/vintage_net_qmi/cell_monitor.ex
+++ b/lib/vintage_net_qmi/cell_monitor.ex
@@ -71,6 +71,25 @@ defmodule VintageNetQMI.CellMonitor do
     state
   end
 
+  defp maybe_post_lte_sys_info(
+         {:ok, %{srv_reg_restriction: :unrestricted, sim_rej_info: reject_info}},
+         state
+       ) do
+    PropertyTable.put_many(VintageNet, [
+      {["interface", state.ifname, "mobile", "sim_rej_info"], reject_info},
+      {["interface", state.ifname, "mobile", "mcc"], nil},
+      {["interface", state.ifname, "mobile", "mnc"], nil},
+      {["interface", state.ifname, "mobile", "provider"], nil}
+    ])
+
+    state
+  end
+
+  defp maybe_post_lte_sys_info({:ok, unhandled}, state) do
+    Logger.warning("[VintageNetQMI] Unhandled LTE SYS info: #{inspect(unhandled)}")
+    state
+  end
+
   defp maybe_post_lte_sys_info({:error, _reason} = error, state) do
     Logger.warning("[VintageNetQMI] failed getting home network: #{inspect(error)}")
     state


### PR DESCRIPTION
Adds a catch all function clause in the cell_monitor for when unexpected values are returned by `get_sys_info/1`.