### PR TITLE
v0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
-## [v0.4.1] - 2024-08-06
+## [v0.5.0] - 2024-08-30
+
+### Added
+
+* `sim_rej_info` has been added to the PropertyTable.
+
+### Changed
+
+* PropertyTable properties have been updated to not contain invalid characters
+  * MNC
+  * MCC
+* `provider` PropertyTable property Will now work correctly with updated MNC/MCC properties.
 
 ### Changed
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule VintageNetQMI.MixProject do
   use Mix.Project
 
-  @version "0.4.1"
+  @version "0.5.0"
   @source_url "https://github.com/nerves-networking/vintage_net_qmi"
 
   def project do


### PR DESCRIPTION
## [v0.5.0] - 2024-08-30

### Added

* `sim_rej_info` has been added to the PropertyTable.

### Changed

* PropertyTable properties have been updated to not contain invalid characters
  * MNC
  * MCC
* `provider` PropertyTable property Will now work correctly with updated MNC/MCC properties.