### PR TITLE
v0.4.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [v0.4.2] - 2024-08-30
+
+### Added
+
+* `sim_rej_info` has been added to the PropertyTable.
+
+### Changed
+
+* PropertyTable properties have been updated to not contain invalid characters
+  * MNC
+  * MCC
+* `provider` PropertyTable property Will now work correctly with updated MNC/MCC properties.
+
 ## [v0.4.1] - 2024-08-06
 
 ### Changed

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule VintageNetQMI.MixProject do
   use Mix.Project
 
-  @version "0.4.1"
+  @version "0.4.2"
   @source_url "https://github.com/nerves-networking/vintage_net_qmi"
 
   def project do


### PR DESCRIPTION
## [v0.4.2] - 2024-08-30

### Added

* `sim_rej_info` has been added to the PropertyTable.

### Changed

* PropertyTable properties have been updated to not contain invalid characters
  * MNC
  * MCC
* `provider` PropertyTable property Will now work correctly with updated MNC/MCC properties.