### PR TITLE
Remove CS Connection Requirement For Derived Internet Status

### DIFF
--- a/lib/vintage_net_qmi/connectivity.ex
+++ b/lib/vintage_net_qmi/connectivity.ex
@@ -247,7 +247,6 @@ defmodule VintageNetQMI.Connectivity do
   #   indication_id: 36,
   #   name: :serving_system_indication,
   #   service_id: 3,
-  #   serving_system_cs_attach_state: :attached,
   #   serving_system_ps_attach_state: :attached,
   #   serving_system_radio_interfaces: [:lte],
   #   serving_system_registration_state: :registered,
@@ -255,7 +254,6 @@ defmodule VintageNetQMI.Connectivity do
   # }
   defp derive_status(%{
          serving_system: %{
-           serving_system_cs_attach_state: :attached,
            serving_system_ps_attach_state: :attached,
            serving_system_radio_interfaces: radio_ifs,
            serving_system_registration_state: :registered,


### PR DESCRIPTION
Hello! 👋🏼 

We are experiencing an issue where it appears cell towers in some regions are no longer providing a CS connection:

```elixir
:sys.get_state(Module.concat(VintageNetQMI.Connectivity, "wwan0"))

%VintageNetQMI.Connectivity{
  ifname: "wwan0",
  reported_status: :disconnected,
  derived_status: :disconnected,
  grace_timer: nil,
  lan?: true,
  ip_address?: true,
  serving_system: %{
    name: :serving_system_indication,
    cell_id: <pos_integer>,
    service_id: 3,
    indication_id: 36,
    serving_system_cs_attach_state: :detached,
    serving_system_ps_attach_state: :attached,
    serving_system_radio_interfaces: [:lte],
    serving_system_registration_state: :registered,
    serving_system_selected_network: :network_3gpp
  },
  packet_data_connection?: true
}
```

In this state, our devices are connected to the internet and are able to transmit data over cell, but eventually vintage net times out waiting for an `:internet` status.

```
Interface wwan0
  Type: VintageNetQMI
  Power: Starting up/on (170345 ms left)
  Present: true
  State: :configured (0:02:27)
  Connection: :lan (0:01:52)
```

From what I can tell, it appears support for CS connections are being phased out by cell providers. Does it make sense to no longer require a CS connection to report a connection to the internet?

I have little experience with cell networking so very open to feedback and discussion here, appreciate any help offered.